### PR TITLE
Add relocation document feature with CRUD operations

### DIFF
--- a/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/AddRelocationDocumentLineCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/AddRelocationDocumentLineCommandValidator.cs
@@ -1,0 +1,36 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Relocation;
+
+[PublicAPI]
+public class AddRelocationDocumentLineCommandValidator : AbstractValidator<AddRelocationDocumentLineCommand>
+{
+    public AddRelocationDocumentLineCommandValidator()
+    {
+        RuleFor(x => x.DocumentId)
+            .NotEmpty()
+            .WithMessage("Relocation document is required");
+
+        RuleFor(x => x.ItemId)
+            .NotEmpty()
+            .WithMessage("Item is required");
+
+        RuleFor(x => x.FromLocationId)
+            .NotEmpty()
+            .WithMessage("From location is required");
+
+        RuleFor(x => x.ToLocationId)
+            .NotEmpty()
+            .WithMessage("To location is required");
+
+        RuleFor(x => x.Quantity.Value)
+            .GreaterThan(0)
+            .WithMessage("Quantity must be greater than 0");
+
+        RuleFor(x => x.DocumentVersion)
+            .GreaterThan(0)
+            .WithMessage("Document version must be greater than 0");
+    }
+}

--- a/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/CreateRelocationDocumentCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/CreateRelocationDocumentCommandValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+using Nimbo.Wms.Domain.Entities.Documents.Common;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Relocation;
+
+[PublicAPI]
+public class CreateRelocationDocumentCommandValidator : AbstractValidator<CreateRelocationDocumentCommand>
+{
+    public CreateRelocationDocumentCommandValidator()
+    {
+        RuleFor(x => x.WarehouseId)
+            .NotEmpty()
+            .WithMessage("Warehouse is required");
+
+        RuleFor(x => x.Code)
+            .NotEmpty()
+            .MaximumLength(IDocument.CodeMaxLength)
+            .WithMessage("Document code is required or exceeds the maximum length of {MaxLength} characters");
+
+        RuleFor(x => x.Title)
+            .NotEmpty()
+            .MaximumLength(IDocument.TitleMaxLength)
+            .WithMessage("Document title is required or exceeds the maximum length of {MaxLength} characters");
+    }
+}

--- a/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/DeleteRelocationDocumentCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/DeleteRelocationDocumentCommandValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Relocation;
+
+[PublicAPI]
+public class DeleteRelocationDocumentCommandValidator : AbstractValidator<DeleteRelocationDocumentCommand>
+{
+    public DeleteRelocationDocumentCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty()
+            .WithMessage("Relocation document is required");
+
+        RuleFor(x => x.Version)
+            .GreaterThan(0)
+            .WithMessage("Document version must be greater than 0");
+    }
+}

--- a/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/DeleteRelocationDocumentLineCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/DeleteRelocationDocumentLineCommandValidator.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Relocation;
+
+[PublicAPI]
+public class DeleteRelocationDocumentLineCommandValidator : AbstractValidator<DeleteRelocationDocumentLineCommand>
+{
+    public DeleteRelocationDocumentLineCommandValidator()
+    {
+        RuleFor(x => x.DocumentId)
+            .NotEmpty()
+            .WithMessage("Relocation document is required");
+
+        RuleFor(x => x.Id)
+            .NotEmpty()
+            .WithMessage("Relocation document line is required");
+
+        RuleFor(x => x.DocumentVersion)
+            .GreaterThan(0)
+            .WithMessage("Document version must be greater than 0");
+    }
+}

--- a/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/PatchRelocationDocumentCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/PatchRelocationDocumentCommandValidator.cs
@@ -1,0 +1,29 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+using Nimbo.Wms.Domain.Entities.Documents.Common;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Relocation;
+
+[PublicAPI]
+public class PatchRelocationDocumentCommandValidator : AbstractValidator<PatchRelocationDocumentCommand>
+{
+    public PatchRelocationDocumentCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty()
+            .WithMessage("Relocation document is required");
+
+        RuleFor(x => x.Code)
+            .MaximumLength(IDocument.CodeMaxLength)
+            .WithMessage("Document code exceeds the maximum length of {MaxLength} characters");
+
+        RuleFor(x => x.Title)
+            .MaximumLength(IDocument.TitleMaxLength)
+            .WithMessage("Document title exceeds the maximum length of {MaxLength} characters");
+
+        RuleFor(x => x.Version)
+            .GreaterThan(0)
+            .WithMessage("Document version must be greater than 0");
+    }
+}

--- a/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/PatchRelocationDocumentLineCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Relocation/PatchRelocationDocumentLineCommandValidator.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Relocation;
+
+[PublicAPI]
+public class PatchRelocationDocumentLineCommandValidator : AbstractValidator<PatchRelocationDocumentLineCommand>
+{
+    public PatchRelocationDocumentLineCommandValidator()
+    {
+        RuleFor(x => x.DocumentId)
+            .NotEmpty()
+            .WithMessage("Relocation document is required");
+
+        RuleFor(x => x.Id)
+            .NotEmpty()
+            .WithMessage("Relocation document line is required");
+
+        RuleFor(x => x.DocumentVersion)
+            .GreaterThan(0)
+            .WithMessage("Document version must be greater than 0");
+    }
+}

--- a/Nimbo.Wms.Application/Mappings/Documents/Relocation/RelocationDocumentLineMapper.cs
+++ b/Nimbo.Wms.Application/Mappings/Documents/Relocation/RelocationDocumentLineMapper.cs
@@ -1,0 +1,20 @@
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+using Nimbo.Wms.Domain.Entities.Documents.Relocation;
+using Riok.Mapperly.Abstractions;
+
+namespace Nimbo.Wms.Application.Mappings.Documents.Relocation;
+
+[PublicAPI]
+[Mapper(EnumMappingStrategy = EnumMappingStrategy.ByName)]
+public partial class RelocationDocumentLineMapper : IMapper<RelocationDocumentLine, RelocationDocumentLineDto>
+{
+    public partial IQueryable<RelocationDocumentLineDto> ProjectToDto(IQueryable<RelocationDocumentLine> items);
+
+    public partial IEnumerable<RelocationDocumentLineDto> MapToDto(IEnumerable<RelocationDocumentLine> items);
+
+    [MapProperty(nameof(RelocationDocumentLine.From), nameof(RelocationDocumentLineDto.FromLocationId))]
+    [MapProperty(nameof(RelocationDocumentLine.To), nameof(RelocationDocumentLineDto.ToLocationId))]
+    public partial RelocationDocumentLineDto MapToDto(RelocationDocumentLine item);
+}

--- a/Nimbo.Wms.Application/Mappings/Documents/Relocation/RelocationDocumentMapper.cs
+++ b/Nimbo.Wms.Application/Mappings/Documents/Relocation/RelocationDocumentMapper.cs
@@ -1,0 +1,18 @@
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+using Nimbo.Wms.Domain.Entities.Documents.Relocation;
+using Riok.Mapperly.Abstractions;
+
+namespace Nimbo.Wms.Application.Mappings.Documents.Relocation;
+
+[PublicAPI]
+[Mapper(EnumMappingStrategy = EnumMappingStrategy.ByName)]
+public partial class RelocationDocumentBodyMapper : IMapper<RelocationDocument, RelocationDocumentBodyDto>
+{
+    public partial IQueryable<RelocationDocumentBodyDto> ProjectToDto(IQueryable<RelocationDocument> items);
+
+    public partial IEnumerable<RelocationDocumentBodyDto> MapToDto(IEnumerable<RelocationDocument> items);
+
+    public partial RelocationDocumentBodyDto MapToDto(RelocationDocument item);
+}

--- a/Nimbo.Wms.Contracts/Documents/Relocation/Commands/AddRelocationDocumentLineCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Relocation/Commands/AddRelocationDocumentLineCommand.cs
@@ -1,0 +1,17 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Common.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+
+[PublicAPI]
+public sealed record AddRelocationDocumentLineCommand(
+    Guid DocumentId,
+    Guid ItemId,
+    Guid FromLocationId,
+    Guid ToLocationId,
+    QuantityDto Quantity,
+    string? Notes,
+    long DocumentVersion
+) : IRequest<Guid>, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Relocation/Commands/CreateRelocationDocumentCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Relocation/Commands/CreateRelocationDocumentCommand.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+
+namespace Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+
+[PublicAPI]
+public sealed record CreateRelocationDocumentCommand(
+    Guid WarehouseId,
+    string Code,
+    string Title
+) : IRequest<Guid>, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Relocation/Commands/DeleteRelocationDocumentCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Relocation/Commands/DeleteRelocationDocumentCommand.cs
@@ -1,0 +1,8 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+
+namespace Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+
+[PublicAPI]
+public record DeleteRelocationDocumentCommand(Guid Id, long Version) : IRequest, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Relocation/Commands/DeleteRelocationDocumentLineCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Relocation/Commands/DeleteRelocationDocumentLineCommand.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+
+namespace Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+
+[PublicAPI]
+public sealed record DeleteRelocationDocumentLineCommand(
+    Guid DocumentId,
+    Guid Id,
+    long DocumentVersion
+) : IRequest, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Relocation/Commands/PatchRelocationDocumentCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Relocation/Commands/PatchRelocationDocumentCommand.cs
@@ -1,0 +1,14 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+
+namespace Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+
+[PublicAPI]
+public sealed record PatchRelocationDocumentCommand(
+    Guid Id,
+    string? Code,
+    string? Title,
+    string? Notes,
+    long Version
+) : IRequest, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Relocation/Commands/PatchRelocationDocumentLineCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Relocation/Commands/PatchRelocationDocumentLineCommand.cs
@@ -1,0 +1,17 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Common.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+
+[PublicAPI]
+public sealed record PatchRelocationDocumentLineCommand(
+    Guid DocumentId,
+    Guid Id,
+    Guid? FromLocationId,
+    Guid? ToLocationId,
+    QuantityDto? Quantity,
+    string? Notes,
+    long DocumentVersion
+) : IRequest, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Relocation/Dtos/RelocationDocumentDto.cs
+++ b/Nimbo.Wms.Contracts/Documents/Relocation/Dtos/RelocationDocumentDto.cs
@@ -1,0 +1,23 @@
+using JetBrains.Annotations;
+
+namespace Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+
+[PublicAPI]
+public sealed record RelocationDocumentBodyDto(
+    Guid Id,
+    Guid WarehouseId,
+    string Code,
+    string Title,
+    string Status,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    DateTime? PostedAt,
+    long Version,
+    string? Notes
+);
+
+[PublicAPI]
+public sealed record RelocationDocumentDto(
+    RelocationDocumentBodyDto Body,
+    List<RelocationDocumentLineDto> Lines
+);

--- a/Nimbo.Wms.Contracts/Documents/Relocation/Dtos/RelocationDocumentLineDto.cs
+++ b/Nimbo.Wms.Contracts/Documents/Relocation/Dtos/RelocationDocumentLineDto.cs
@@ -1,0 +1,15 @@
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Common.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+
+[PublicAPI]
+public sealed record RelocationDocumentLineDto(
+    Guid Id,
+    Guid DocumentId,
+    Guid ItemId,
+    Guid FromLocationId,
+    Guid ToLocationId,
+    QuantityDto Quantity,
+    string? Notes
+);

--- a/Nimbo.Wms.Contracts/Documents/Relocation/Queries/GetRelocationDocumentLinesQuery.cs
+++ b/Nimbo.Wms.Contracts/Documents/Relocation/Queries/GetRelocationDocumentLinesQuery.cs
@@ -1,0 +1,8 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Relocation.Queries;
+
+[PublicAPI]
+public sealed record GetRelocationDocumentLinesQuery(Guid Id) : IRequest<List<RelocationDocumentLineDto>>;

--- a/Nimbo.Wms.Contracts/Documents/Relocation/Queries/GetRelocationDocumentQuery.cs
+++ b/Nimbo.Wms.Contracts/Documents/Relocation/Queries/GetRelocationDocumentQuery.cs
@@ -1,0 +1,8 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Relocation.Queries;
+
+[PublicAPI]
+public sealed record GetRelocationDocumentQuery(Guid Id) : IRequest<RelocationDocumentDto>;

--- a/Nimbo.Wms.Contracts/Documents/Relocation/Queries/GetRelocationDocumentsQuery.cs
+++ b/Nimbo.Wms.Contracts/Documents/Relocation/Queries/GetRelocationDocumentsQuery.cs
@@ -1,0 +1,8 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Relocation.Queries;
+
+[PublicAPI]
+public record GetRelocationDocumentsQuery : IRequest<List<RelocationDocumentBodyDto>>;

--- a/Nimbo.Wms.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Nimbo.Wms.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ using Nimbo.Wms.Application.Mappings.MasterData;
 using Nimbo.Wms.Application.Mappings.Stock;
 using Nimbo.Wms.Application.Mappings.Topology;
 using Nimbo.Wms.Application.Mappings.Documents.Receiving;
+using Nimbo.Wms.Application.Mappings.Documents.Relocation;
 using Nimbo.Wms.Application.Mappings.Documents.Shipment;
 using Nimbo.Wms.Application.Services.Documents;
 using Nimbo.Wms.Contracts.Common;
@@ -23,6 +24,7 @@ using Nimbo.Wms.Contracts.MasterData.Dtos;
 using Nimbo.Wms.Contracts.Stock.Dtos;
 using Nimbo.Wms.Contracts.Topology.Dtos;
 using Nimbo.Wms.Contracts.Documents.Receiving.Dtos;
+using Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
 using Nimbo.Wms.Contracts.Documents.Shipment.Dtos;
 using Nimbo.Wms.Domain.Entities.Documents.Adjustment;
 using Nimbo.Wms.Domain.Entities.Documents.CycleCount;
@@ -122,9 +124,14 @@ public static class ServiceCollectionExtensions
         {
             services.AddScoped<IMapper<ReceivingDocument, ReceivingDocumentBodyDto>, ReceivingDocumentBodyMapper>();
             services.AddScoped<IMapper<ReceivingDocumentLine, ReceivingDocumentLineDto>, ReceivingDocumentLineMapper>();
+
+            services.AddScoped<IMapper<RelocationDocument, RelocationDocumentBodyDto>, RelocationDocumentBodyMapper>();
+            services.AddScoped<IMapper<RelocationDocumentLine, RelocationDocumentLineDto>, RelocationDocumentLineMapper>();
+
             services.AddScoped<IMapper<ShipmentDocument, ShipmentDocumentBodyDto>, ShipmentDocumentBodyMapper>();
             services.AddScoped<IMapper<ShipmentDocumentLine, ShipmentDocumentLineDto>, ShipmentDocumentLineMapper>();
             services.AddScoped<IMapper<ShipmentPickLine, ShipmentPickLineDto>, ShipmentPickLineMapper>();
+
             services.AddScoped<IMapper<CycleCountDocument, CycleCountDocumentBodyDto>, CycleCountDocumentBodyMapper>();
             services.AddScoped<IMapper<CycleCountDocumentLine, CycleCountDocumentLineDto>, CycleCountDocumentLineMapper>();
 

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/AddRelocationDocumentLineCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/AddRelocationDocumentLineCommandHandler.cs
@@ -1,0 +1,47 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.MasterData;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+using Nimbo.Wms.Domain.Identification;
+using Nimbo.Wms.Domain.References;
+using Nimbo.Wms.Domain.ValueObject;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Relocation;
+
+[PublicAPI]
+public class AddRelocationDocumentLineCommandHandler : IRequestHandler<AddRelocationDocumentLineCommand, Guid>
+{
+    private readonly IRelocationDocumentRepository _repository;
+    private readonly IItemRepository _itemRepository;
+
+    public AddRelocationDocumentLineCommandHandler(IRelocationDocumentRepository repository, IItemRepository itemRepository)
+    {
+        _repository = repository;
+        _itemRepository = itemRepository;
+    }
+
+    public async Task<Guid> Handle(AddRelocationDocumentLineCommand request, CancellationToken ct)
+    {
+        var documentId = RelocationDocumentId.From(request.DocumentId);
+        var document = await _repository.GetByIdWithLinesAsync(documentId, ct);
+        if (document is null)
+            throw new NotFoundException($"Relocation document with ID '{documentId}' not found");
+
+        if (document.Version > request.DocumentVersion)
+            throw new ConcurrencyException($"Document version mismatch. Expected: {document.Version}, Actual: {request.DocumentVersion}");
+
+        var itemId = ItemId.From(request.ItemId);
+        var item = await _itemRepository.GetByIdAsync(itemId, ct);
+        if (item is null)
+            throw new InvalidOperationException($"Item with ID '{itemId}' not found");
+
+        var fromLocationId = LocationId.From(request.FromLocationId);
+        var toLocationId = LocationId.From(request.ToLocationId);
+        var uom = Enum.Parse<UnitOfMeasure>(request.Quantity.Uom);
+        var quantity = new Quantity(request.Quantity.Value, uom);
+
+        return document.AddLine(itemId, quantity, fromLocationId, toLocationId, request.Notes);
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/CreateRelocationDocumentCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/CreateRelocationDocumentCommandHandler.cs
@@ -1,0 +1,30 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+using Nimbo.Wms.Domain.Entities.Documents.Relocation;
+using Nimbo.Wms.Domain.Identification;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Relocation;
+
+[PublicAPI]
+public class CreateRelocationDocumentCommandHandler : IRequestHandler<CreateRelocationDocumentCommand, Guid>
+{
+    private readonly IRelocationDocumentRepository _repository;
+
+    public CreateRelocationDocumentCommandHandler(IRelocationDocumentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Guid> Handle(CreateRelocationDocumentCommand request, CancellationToken ct)
+    {
+        var warehouseId = WarehouseId.From(request.WarehouseId);
+        var documentId = RelocationDocumentId.New();
+
+        var document = new RelocationDocument(documentId, warehouseId, request.Code, request.Title, DateTime.UtcNow);
+        await _repository.AddAsync(document, ct);
+
+        return documentId;
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/DeleteRelocationDocumentCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/DeleteRelocationDocumentCommandHandler.cs
@@ -1,0 +1,34 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+using Nimbo.Wms.Domain.Identification;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Relocation;
+
+[PublicAPI]
+public class DeleteRelocationDocumentCommandHandler : IRequestHandler<DeleteRelocationDocumentCommand>
+{
+    private readonly IRelocationDocumentRepository _repository;
+
+    public DeleteRelocationDocumentCommandHandler(IRelocationDocumentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(DeleteRelocationDocumentCommand request, CancellationToken ct)
+    {
+        var documentId = RelocationDocumentId.From(request.Id);
+        var document = await _repository.GetByIdAsync(documentId, ct);
+
+        if (document == null)
+            throw new NotFoundException($"Relocation document with ID {documentId} not found");
+
+        if (document.Version > request.Version)
+            throw new ConcurrencyException($"Document version mismatch. Expected: {document.Version}, Actual: {request.Version}");
+
+        document.EnsureCanBeEdited();
+        await _repository.DeleteAsync(document, ct);
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/DeleteRelocationDocumentLineCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/DeleteRelocationDocumentLineCommandHandler.cs
@@ -1,0 +1,32 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+using Nimbo.Wms.Domain.Identification;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Relocation;
+
+[PublicAPI]
+public class DeleteRelocationDocumentLineCommandHandler : IRequestHandler<DeleteRelocationDocumentLineCommand>
+{
+    private readonly IRelocationDocumentRepository _repository;
+
+    public DeleteRelocationDocumentLineCommandHandler(IRelocationDocumentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(DeleteRelocationDocumentLineCommand request, CancellationToken ct)
+    {
+        var documentId = RelocationDocumentId.From(request.DocumentId);
+        var document = await _repository.GetByIdWithLinesAsync(documentId, ct);
+        if (document is null)
+            throw new NotFoundException($"Relocation document with ID '{documentId}' not found");
+
+        if (document.Version > request.DocumentVersion)
+            throw new ConcurrencyException($"Document version mismatch. Expected: {document.Version}, Actual: {request.DocumentVersion}");
+
+        document.RemoveLine(request.Id);
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/GetRelocationDocumentLinesQueryHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/GetRelocationDocumentLinesQueryHandler.cs
@@ -1,0 +1,35 @@
+using JetBrains.Annotations;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+using Nimbo.Wms.Contracts.Documents.Relocation.Queries;
+using Nimbo.Wms.Domain.Entities.Documents.Relocation;
+using Nimbo.Wms.Domain.Identification;
+using Nimbo.Wms.Infrastructure.Persistence;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Relocation;
+
+[PublicAPI]
+public class GetRelocationDocumentLinesQueryHandler : IRequestHandler<GetRelocationDocumentLinesQuery, List<RelocationDocumentLineDto>>
+{
+    private readonly NimboWmsDbContext _dbContext;
+    private readonly IMapper<RelocationDocumentLine, RelocationDocumentLineDto> _mapper;
+
+    public GetRelocationDocumentLinesQueryHandler(NimboWmsDbContext dbContext, IMapper<RelocationDocumentLine, RelocationDocumentLineDto> mapper)
+    {
+        _dbContext = dbContext;
+        _mapper = mapper;
+    }
+
+    public async Task<List<RelocationDocumentLineDto>> Handle(GetRelocationDocumentLinesQuery request, CancellationToken ct)
+    {
+        var documentId = RelocationDocumentId.From(request.Id);
+        var dbQuery = _dbContext.Set<RelocationDocumentLine>()
+            .AsNoTracking()
+            .Where(x => x.DocumentId == documentId);
+            
+        var lines = await _mapper.ProjectToDto(dbQuery).ToListAsync(ct);
+        return lines;
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/GetRelocationDocumentQueryHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/GetRelocationDocumentQueryHandler.cs
@@ -1,0 +1,45 @@
+using JetBrains.Annotations;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+using Nimbo.Wms.Contracts.Documents.Relocation.Queries;
+using Nimbo.Wms.Domain.Entities.Documents.Relocation;
+using Nimbo.Wms.Domain.Identification;
+using Nimbo.Wms.Infrastructure.Persistence;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Relocation;
+
+[PublicAPI]
+public class GetRelocationDocumentQueryHandler : IRequestHandler<GetRelocationDocumentQuery, RelocationDocumentDto>
+{
+    private readonly NimboWmsDbContext _dbContext;
+    private readonly IMapper<RelocationDocument, RelocationDocumentBodyDto> _documentMapper;
+    private readonly IMapper<RelocationDocumentLine, RelocationDocumentLineDto> _lineMapper;
+
+    public GetRelocationDocumentQueryHandler(NimboWmsDbContext dbContext, IMapper<RelocationDocument, RelocationDocumentBodyDto> documentMapper, IMapper<RelocationDocumentLine, RelocationDocumentLineDto> lineMapper)
+    {
+        _dbContext = dbContext;
+        _documentMapper = documentMapper;
+        _lineMapper = lineMapper;
+    }
+
+    public async Task<RelocationDocumentDto> Handle(GetRelocationDocumentQuery request, CancellationToken ct)
+    {
+        var documentId = RelocationDocumentId.From(request.Id);
+        
+        var document = await _dbContext.Set<RelocationDocument>()
+            .AsNoTracking()
+            .Include(x => x.Lines)
+            .FirstOrDefaultAsync(x => x.Id == documentId, ct);
+
+        if (document == null)
+            throw new NotFoundException($"Relocation document with ID '{request.Id}' not found.");
+
+        var bodyDto = _documentMapper.MapToDto(document);
+        var linesDto = _lineMapper.MapToDto(document.Lines).ToList();
+
+        return new RelocationDocumentDto(bodyDto, linesDto);
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/GetRelocationDocumentsQueryHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/GetRelocationDocumentsQueryHandler.cs
@@ -1,0 +1,30 @@
+using JetBrains.Annotations;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+using Nimbo.Wms.Contracts.Documents.Relocation.Queries;
+using Nimbo.Wms.Domain.Entities.Documents.Relocation;
+using Nimbo.Wms.Infrastructure.Persistence;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Relocation;
+
+[PublicAPI]
+public class GetRelocationDocumentsQueryHandler : IRequestHandler<GetRelocationDocumentsQuery, List<RelocationDocumentBodyDto>>
+{
+    private readonly NimboWmsDbContext _dbContext;
+    private readonly IMapper<RelocationDocument, RelocationDocumentBodyDto> _mapper;
+
+    public GetRelocationDocumentsQueryHandler(NimboWmsDbContext dbContext, IMapper<RelocationDocument, RelocationDocumentBodyDto> mapper)
+    {
+        _dbContext = dbContext;
+        _mapper = mapper;
+    }
+
+    public async Task<List<RelocationDocumentBodyDto>> Handle(GetRelocationDocumentsQuery request, CancellationToken ct)
+    {
+        var dbQuery = _dbContext.Set<RelocationDocument>().AsNoTracking();
+        var documents = await _mapper.ProjectToDto(dbQuery).ToListAsync(ct);
+        return documents;
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/PatchRelocationDocumentCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/PatchRelocationDocumentCommandHandler.cs
@@ -1,0 +1,39 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+using Nimbo.Wms.Domain.Identification;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Relocation;
+
+[PublicAPI]
+public class PatchRelocationDocumentCommandHandler : IRequestHandler<PatchRelocationDocumentCommand>
+{
+    private readonly IRelocationDocumentRepository _repository;
+
+    public PatchRelocationDocumentCommandHandler(IRelocationDocumentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(PatchRelocationDocumentCommand request, CancellationToken ct)
+    {
+        var documentId = RelocationDocumentId.From(request.Id);
+        var document = await _repository.GetByIdAsync(documentId, ct);
+        if (document is null)
+            throw new NotFoundException($"Relocation document with ID '{documentId}' not found.");
+
+        if (document.Version > request.Version)
+            throw new ConcurrencyException($"Document version mismatch. Expected: {document.Version}, Actual: {request.Version}");
+
+        if (!string.IsNullOrWhiteSpace(request.Code))
+            document.ChangeCode(request.Code);
+
+        if (!string.IsNullOrWhiteSpace(request.Title))
+            document.ChangeCode(request.Title);
+
+        if (!string.IsNullOrWhiteSpace(request.Notes))
+            document.ChangeNotes(request.Notes);
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/PatchRelocationDocumentLineCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Relocation/PatchRelocationDocumentLineCommandHandler.cs
@@ -1,0 +1,55 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+using Nimbo.Wms.Domain.Identification;
+using Nimbo.Wms.Domain.References;
+using Nimbo.Wms.Domain.ValueObject;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Relocation;
+
+[PublicAPI]
+public class PatchRelocationDocumentLineCommandHandler : IRequestHandler<PatchRelocationDocumentLineCommand>
+{
+    private readonly IRelocationDocumentRepository _repository;
+
+    public PatchRelocationDocumentLineCommandHandler(IRelocationDocumentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(PatchRelocationDocumentLineCommand request, CancellationToken ct)
+    {
+        var documentId = RelocationDocumentId.From(request.DocumentId);
+        var document = await _repository.GetByIdWithLinesAsync(documentId, ct);
+        if (document is null)
+            throw new NotFoundException($"Relocation document with ID '{documentId}' not found");
+
+        if (document.Version > request.DocumentVersion)
+            throw new ConcurrencyException($"Document version mismatch. Expected: {document.Version}, Actual: {request.DocumentVersion}");
+
+        if (request.Quantity is not null)
+        {
+            var value = request.Quantity.Value;
+            var uom = Enum.Parse<UnitOfMeasure>(request.Quantity.Uom);
+
+            var quantity = new Quantity(value, uom);
+            document.ChangeLineRelocationQuantity(request.Id, quantity);
+        }
+
+        if (request.FromLocationId is not null)
+        {
+            document.ChangeLineFrom(request.Id, LocationId.From(request.FromLocationId.Value));
+        }
+
+        if (request.ToLocationId is not null)
+        {
+            document.ChangeLineTo(request.Id, LocationId.From(request.ToLocationId.Value));
+        }
+
+        var line = document.GetLine(request.Id);
+        if (request.Notes is not null)
+            line.ChangeNotes(request.Notes);
+    }
+}

--- a/Nimbo.Wms/Controllers/Documents/RelocationDocumentLinesController.cs
+++ b/Nimbo.Wms/Controllers/Documents/RelocationDocumentLinesController.cs
@@ -1,0 +1,115 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+using Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+using Nimbo.Wms.Contracts.Documents.Relocation.Queries;
+using Nimbo.Wms.Models.Documents.Relocation;
+
+namespace Nimbo.Wms.Controllers.Documents;
+
+[ApiController]
+[Route("api/documents/relocation/{documentGuid:guid}/lines")]
+public class RelocationDocumentLinesController(ISender sender) : ControllerBase
+{
+    /// <summary>
+    /// Adds a new line to the relocation document.
+    /// </summary>
+    /// <param name="documentGuid">The unique identifier of the relocation document to which the line will be added.</param>
+    /// <param name="request">The details of the line to be added, including item ID, origin and destination locations, quantity, notes, and the document version.</param>
+    /// <param name="ct">The cancellation token to observe, which can be used to send a cancellation request to the operation.</param>
+    /// <returns>Returns an HTTP 201 Created response containing the unique identifier of the newly created line.</returns>
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [Produces("application/json")]
+    public async Task<IActionResult> AddLine(
+        Guid documentGuid,
+        [FromBody] AddRelocationDocumentLineRequest request,
+        CancellationToken ct)
+    {
+        var command = new AddRelocationDocumentLineCommand(
+            documentGuid,
+            request.ItemId,
+            request.FromLocationId,
+            request.ToLocationId,
+            request.Quantity,
+            request.Notes,
+            request.DocumentVersion);
+
+        var lineGuid = await sender.Send(command, ct);
+        return CreatedAtAction(
+            nameof(GetLines),
+            new { documentGuid, lineGuid },
+            new AddRelocationDocumentLineResponse(lineGuid));
+    }
+
+    /// <summary>
+    /// Retrieves all lines associated with the specified relocation document.
+    /// </summary>
+    /// <param name="documentGuid">The unique identifier of the relocation document from which lines are to be retrieved.</param>
+    /// <param name="ct">The cancellation token to observe, which can be used to send a cancellation request to the operation.</param>
+    /// <returns>Returns a list of relocation document lines, including details regarding item ID, origin and destination locations, quantity, and notes.</returns>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [Produces("application/json")]
+    public async Task<IReadOnlyList<RelocationDocumentLineDto>> GetLines(
+        Guid documentGuid,
+        CancellationToken ct)
+    {
+        var query = new GetRelocationDocumentLinesQuery(documentGuid);
+        return await sender.Send(query, ct);
+    }
+
+    /// <summary>
+    /// Updates the specified line in the relocation document with the provided details.
+    /// </summary>
+    /// <param name="documentGuid">The unique identifier of the relocation document containing the line to be updated.</param>
+    /// <param name="lineGuid">The unique identifier of the line to be updated within the relocation document.</param>
+    /// <param name="request">The details to update the line, including optional origin and destination locations, quantity, and notes, along with the document version for concurrency control.</param>
+    /// <param name="ct">The cancellation token to observe, which can be used to send a cancellation request to the operation.</param>
+    /// <returns>Returns an HTTP 204 No Content response if the update is successful, or an HTTP 404 Not Found response if the line does not exist.</returns>
+    [HttpPatch("{lineGuid:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> PatchLine(
+        Guid documentGuid,
+        Guid lineGuid,
+        [FromBody] PatchRelocationDocumentLineRequest request,
+        CancellationToken ct)
+    {
+        var command = new PatchRelocationDocumentLineCommand(
+            documentGuid,
+            lineGuid,
+            request.FromLocationId,
+            request.ToLocationId,
+            request.Quantity,
+            request.Notes,
+            request.DocumentVersion);
+        await sender.Send(command, ct);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Deletes a specific line from the relocation document.
+    /// </summary>
+    /// <param name="documentGuid">The unique identifier of the relocation document from which the line will be deleted.</param>
+    /// <param name="lineGuid">The unique identifier of the line to be deleted.</param>
+    /// <param name="documentVersion">The version of the relocation document to validate against for concurrency control.</param>
+    /// <param name="ct">The cancellation token to observe, which can be used to send a cancellation request to the operation.</param>
+    /// <returns>Returns an HTTP 204 No Content response if the deletion is successful; otherwise, it returns an HTTP 404 Not Found response if the line does not exist.</returns>
+    [HttpDelete("{lineGuid:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteLine(
+        Guid documentGuid,
+        Guid lineGuid,
+        [FromQuery] long documentVersion,
+        CancellationToken ct)
+    {
+        var command = new DeleteRelocationDocumentLineCommand(
+            documentGuid,
+            lineGuid,
+            documentVersion);
+        await sender.Send(command, ct);
+        return NoContent();
+    }
+}

--- a/Nimbo.Wms/Controllers/Documents/RelocationDocumentsController.cs
+++ b/Nimbo.Wms/Controllers/Documents/RelocationDocumentsController.cs
@@ -1,0 +1,110 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Nimbo.Wms.Contracts.Documents.Relocation.Commands;
+using Nimbo.Wms.Contracts.Documents.Relocation.Dtos;
+using Nimbo.Wms.Contracts.Documents.Relocation.Queries;
+using Nimbo.Wms.Models.Documents.Relocation;
+
+namespace Nimbo.Wms.Controllers.Documents;
+
+[ApiController]
+[Route("api/documents/relocation")]
+public class RelocationDocumentsController(ISender sender) : ControllerBase
+{
+    /// <summary>
+    /// Creates a new relocation document based on the provided request data.
+    /// </summary>
+    /// <param name="request">The details of the relocation document to create, including warehouse ID, code, title, and optional notes.</param>
+    /// <param name="ct">The cancellation token used to propagate notifications that operations should be canceled.</param>
+    /// <returns>Returns a 201 Created response with the unique identifier of the newly created relocation document.</returns>
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [Produces("application/json")]
+    public async Task<IActionResult> CreateDocument(
+        [FromBody] CreateRelocationDocumentRequest request,
+        CancellationToken ct)
+    {
+        var command = new CreateRelocationDocumentCommand(
+            request.WarehouseId,
+            request.Code,
+            request.Title);
+        var documentGuid = await sender.Send(command, ct);
+
+        return CreatedAtAction(
+            actionName: nameof(GetDocument),
+            new { documentGuid = documentGuid },
+            new CreateRelocationDocumentResponse(documentGuid));
+    }
+
+    /// <summary>
+    /// Retrieves a list of all relocation documents.
+    /// </summary>
+    /// <param name="ct">The cancellation token used to propagate notifications that operations should be canceled.</param>
+    /// <returns>Returns a collection of relocation documents, including details such as ID, warehouse ID, code, title, status, timestamps, version, and optional notes.</returns>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [Produces("application/json")]
+    public async Task<IReadOnlyList<RelocationDocumentBodyDto>> GetDocuments(CancellationToken ct)
+    {
+        var query = new GetRelocationDocumentsQuery();
+        return await sender.Send(query, ct);
+    }
+
+    /// <summary>
+    /// Retrieves a specific relocation document by its unique identifier.
+    /// </summary>
+    /// <param name="documentGuid">The unique identifier of the relocation document to retrieve.</param>
+    /// <param name="ct">The cancellation token used to propagate notifications that operations should be canceled.</param>
+    /// <returns>Returns the details of the specified relocation document, including
+    [HttpGet("{documentGuid:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [Produces("application/json")]
+    public async Task<RelocationDocumentDto> GetDocument(Guid documentGuid, CancellationToken ct)
+    {
+        var query = new GetRelocationDocumentQuery(documentGuid);
+        return await sender.Send(query, ct);
+    }
+
+    /// <summary>
+    /// Updates an existing relocation document with the specified changes.
+    /// </summary>
+    /// <param name="documentGuid">The unique identifier of the relocation document to update.</param>
+    /// <param name="request">The details of the changes to apply to the relocation document, including optional updates to code, title, notes, and the expected version for concurrency control.</param>
+    /// <param name="ct">The cancellation token used to propagate notifications that operations should be canceled.</param>
+    /// <returns>Returns a 204 No Content response if the update is successful or a 404 Not Found response if the document does not exist.</returns>
+    [HttpPatch("{documentGuid:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> PatchDocument(
+        Guid documentGuid,
+        [FromBody] PatchRelocationDocumentRequest request,
+        CancellationToken ct)
+    {
+        var command = new PatchRelocationDocumentCommand(
+            documentGuid,
+            request.Code,
+            request.Title,
+            request.Notes,
+            request.Version);
+        await sender.Send(command, ct);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Deletes an existing relocation document based on the provided document identifier and version.
+    /// </summary>
+    /// <param name="documentGuid">The unique identifier of the relocation document to delete.</param>
+    /// <param name="version">The version of the relocation document to ensure optimistic concurrency control.</param>
+    /// <param name="ct">The cancellation token used to propagate notifications that operations should be canceled.</param>
+    /// <returns>Returns a 204 No Content response if the deletion is successful, or a 404 Not Found response if the document does not exist.</returns>
+    [HttpDelete("{documentGuid:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteDocument(Guid documentGuid, [FromQuery] long version, CancellationToken ct)
+    {
+        var command = new DeleteRelocationDocumentCommand(documentGuid, version);
+        await sender.Send(command, ct);
+        return NoContent();
+    }
+}

--- a/Nimbo.Wms/Models/Documents/Relocation/AddRelocationDocumentLineRequest.cs
+++ b/Nimbo.Wms/Models/Documents/Relocation/AddRelocationDocumentLineRequest.cs
@@ -1,0 +1,14 @@
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Common.Dtos;
+
+namespace Nimbo.Wms.Models.Documents.Relocation;
+
+[PublicAPI]
+public sealed record AddRelocationDocumentLineRequest(
+    Guid ItemId,
+    Guid FromLocationId,
+    Guid ToLocationId,
+    QuantityDto Quantity,
+    string? Notes,
+    long DocumentVersion
+);

--- a/Nimbo.Wms/Models/Documents/Relocation/AddRelocationDocumentLineResponse.cs
+++ b/Nimbo.Wms/Models/Documents/Relocation/AddRelocationDocumentLineResponse.cs
@@ -1,0 +1,6 @@
+using JetBrains.Annotations;
+
+namespace Nimbo.Wms.Models.Documents.Relocation;
+
+[PublicAPI]
+public sealed record AddRelocationDocumentLineResponse(Guid LineId);

--- a/Nimbo.Wms/Models/Documents/Relocation/CreateRelocationDocumentRequest.cs
+++ b/Nimbo.Wms/Models/Documents/Relocation/CreateRelocationDocumentRequest.cs
@@ -1,0 +1,11 @@
+using JetBrains.Annotations;
+
+namespace Nimbo.Wms.Models.Documents.Relocation;
+
+[PublicAPI]
+public sealed record CreateRelocationDocumentRequest(
+    Guid WarehouseId,
+    string Code,
+    string Title,
+    string? Notes
+);

--- a/Nimbo.Wms/Models/Documents/Relocation/CreateRelocationDocumentResponse.cs
+++ b/Nimbo.Wms/Models/Documents/Relocation/CreateRelocationDocumentResponse.cs
@@ -1,0 +1,6 @@
+using JetBrains.Annotations;
+
+namespace Nimbo.Wms.Models.Documents.Relocation;
+
+[PublicAPI]
+public sealed record CreateRelocationDocumentResponse(Guid DocumentId);

--- a/Nimbo.Wms/Models/Documents/Relocation/PatchRelocationDocumentLineRequest.cs
+++ b/Nimbo.Wms/Models/Documents/Relocation/PatchRelocationDocumentLineRequest.cs
@@ -1,0 +1,13 @@
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Common.Dtos;
+
+namespace Nimbo.Wms.Models.Documents.Relocation;
+
+[PublicAPI]
+public sealed record PatchRelocationDocumentLineRequest(
+    Guid? FromLocationId,
+    Guid? ToLocationId,
+    QuantityDto? Quantity,
+    string? Notes,
+    long DocumentVersion
+);

--- a/Nimbo.Wms/Models/Documents/Relocation/PatchRelocationDocumentRequest.cs
+++ b/Nimbo.Wms/Models/Documents/Relocation/PatchRelocationDocumentRequest.cs
@@ -1,0 +1,11 @@
+using JetBrains.Annotations;
+
+namespace Nimbo.Wms.Models.Documents.Relocation;
+
+[PublicAPI]
+public sealed record PatchRelocationDocumentRequest(
+    string? Code,
+    string? Title,
+    string? Notes,
+    long Version
+);


### PR DESCRIPTION
This pull request introduces the relocation document feature, which includes:

- Handlers for relocation document commands and queries, implementing full CRUD operations.
- Controllers for relocation documents and their line items, exposing CRUD endpoints.
- Models, DTOs, request/response records, validators, mappers, and DI registrations associated with the relocation document functionality.
