### PR TITLE
Add adjustment document feature with CRUD support

### DIFF
--- a/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/AddAdjustmentDocumentLineCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/AddAdjustmentDocumentLineCommandValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Adjustment;
+
+[PublicAPI]
+public class AddAdjustmentDocumentLineCommandValidator : AbstractValidator<AddAdjustmentDocumentLineCommand>
+{
+    public AddAdjustmentDocumentLineCommandValidator()
+    {
+        RuleFor(x => x.ItemId).NotEmpty();
+        RuleFor(x => x.LocationId).NotEmpty();
+        RuleFor(x => x.Delta).NotNull();
+        RuleFor(x => x.DocumentVersion).GreaterThan(0);
+    }
+}

--- a/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/CreateAdjustmentDocumentCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/CreateAdjustmentDocumentCommandValidator.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+using Nimbo.Wms.Domain.Entities.Documents.Common;
+using Nimbo.Wms.Domain.Entities.Documents.Adjustment;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Adjustment;
+
+[PublicAPI]
+public class CreateAdjustmentDocumentCommandValidator : AbstractValidator<CreateAdjustmentDocumentCommand>
+{
+    public CreateAdjustmentDocumentCommandValidator()
+    {
+        RuleFor(x => x.WarehouseId)
+            .NotEmpty()
+            .WithMessage("Warehouse is required");
+
+        RuleFor(x => x.Code)
+            .NotEmpty()
+            .MaximumLength(IDocument.CodeMaxLength)
+            .WithMessage("Document code is required or exceeds the maximum length of {MaxLength} characters");
+
+        RuleFor(x => x.Title)
+            .NotEmpty()
+            .MaximumLength(IDocument.TitleMaxLength)
+            .WithMessage("Document title is required or exceeds the maximum length of {MaxLength} characters");
+
+        RuleFor(x => x.ReasonCode)
+            .NotEmpty()
+            .MaximumLength(AdjustmentDocument.ReasonCodeMaxLength)
+            .WithMessage("Reason code is required or exceeds the maximum length of {MaxLength} characters");
+
+        RuleFor(x => x.ReasonText)
+            .MaximumLength(AdjustmentDocument.ReasonTextMaxLength)
+            .WithMessage("Reason text exceeds the maximum length of {MaxLength} characters");
+    }
+}

--- a/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/DeleteAdjustmentDocumentCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/DeleteAdjustmentDocumentCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Adjustment;
+
+[PublicAPI]
+public class DeleteAdjustmentDocumentCommandValidator : AbstractValidator<DeleteAdjustmentDocumentCommand>
+{
+    public DeleteAdjustmentDocumentCommandValidator()
+    {
+        RuleFor(x => x.Version)
+            .GreaterThan(0)
+            .WithMessage("Document version must be greater than 0");
+    }
+}

--- a/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/DeleteAdjustmentDocumentLineCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/DeleteAdjustmentDocumentLineCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Adjustment;
+
+[PublicAPI]
+public class DeleteAdjustmentDocumentLineCommandValidator : AbstractValidator<DeleteAdjustmentDocumentLineCommand>
+{
+    public DeleteAdjustmentDocumentLineCommandValidator()
+    {
+        RuleFor(x => x.DocumentVersion).GreaterThan(0);
+    }
+}

--- a/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/PatchAdjustmentDocumentCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/PatchAdjustmentDocumentCommandValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+using Nimbo.Wms.Domain.Entities.Documents.Common;
+using Nimbo.Wms.Domain.Entities.Documents.Adjustment;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Adjustment;
+
+[PublicAPI]
+public class PatchAdjustmentDocumentCommandValidator : AbstractValidator<PatchAdjustmentDocumentCommand>
+{
+    public PatchAdjustmentDocumentCommandValidator()
+    {
+        RuleFor(x => x.Code)
+            .MaximumLength(IDocument.CodeMaxLength)
+            .When(x => x.Code != null);
+
+        RuleFor(x => x.Title)
+            .MaximumLength(IDocument.TitleMaxLength)
+            .When(x => x.Title != null);
+
+        RuleFor(x => x.ReasonCode)
+            .MaximumLength(AdjustmentDocument.ReasonCodeMaxLength)
+            .When(x => x.ReasonCode != null);
+
+        RuleFor(x => x.ReasonText)
+            .MaximumLength(AdjustmentDocument.ReasonTextMaxLength)
+            .When(x => x.ReasonText != null);
+
+        RuleFor(x => x.Version)
+            .GreaterThan(0)
+            .WithMessage("Document version must be greater than 0");
+    }
+}

--- a/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/PatchAdjustmentDocumentLineCommandValidator.cs
+++ b/Nimbo.Wms.Application/Common/Validators/Documents/Adjustment/PatchAdjustmentDocumentLineCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+
+namespace Nimbo.Wms.Application.Common.Validators.Documents.Adjustment;
+
+[PublicAPI]
+public class PatchAdjustmentDocumentLineCommandValidator : AbstractValidator<PatchAdjustmentDocumentLineCommand>
+{
+    public PatchAdjustmentDocumentLineCommandValidator()
+    {
+        RuleFor(x => x.DocumentVersion).GreaterThan(0);
+    }
+}

--- a/Nimbo.Wms.Application/Mappings/Documents/Adjustment/AdjustmentDocumentLineMapper.cs
+++ b/Nimbo.Wms.Application/Mappings/Documents/Adjustment/AdjustmentDocumentLineMapper.cs
@@ -1,0 +1,19 @@
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+using Nimbo.Wms.Domain.Entities.Documents.Adjustment;
+using Riok.Mapperly.Abstractions;
+
+namespace Nimbo.Wms.Application.Mappings.Documents.Adjustment;
+
+[PublicAPI]
+[Mapper(EnumMappingStrategy = EnumMappingStrategy.ByName)]
+public partial class AdjustmentDocumentLineMapper : IMapper<AdjustmentDocumentLine, AdjustmentDocumentLineDto>
+{
+    public partial IQueryable<AdjustmentDocumentLineDto> ProjectToDto(IQueryable<AdjustmentDocumentLine> items);
+
+    public partial IEnumerable<AdjustmentDocumentLineDto> MapToDto(IEnumerable<AdjustmentDocumentLine> items);
+
+    [MapperIgnoreSource(nameof(AdjustmentDocumentLine.Quantity))]
+    public partial AdjustmentDocumentLineDto MapToDto(AdjustmentDocumentLine item);
+}

--- a/Nimbo.Wms.Application/Mappings/Documents/Adjustment/AdjustmentDocumentMapper.cs
+++ b/Nimbo.Wms.Application/Mappings/Documents/Adjustment/AdjustmentDocumentMapper.cs
@@ -1,0 +1,18 @@
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+using Nimbo.Wms.Domain.Entities.Documents.Adjustment;
+using Riok.Mapperly.Abstractions;
+
+namespace Nimbo.Wms.Application.Mappings.Documents.Adjustment;
+
+[PublicAPI]
+[Mapper(EnumMappingStrategy = EnumMappingStrategy.ByName)]
+public partial class AdjustmentDocumentBodyMapper : IMapper<AdjustmentDocument, AdjustmentDocumentBodyDto>
+{
+    public partial IQueryable<AdjustmentDocumentBodyDto> ProjectToDto(IQueryable<AdjustmentDocument> items);
+
+    public partial IEnumerable<AdjustmentDocumentBodyDto> MapToDto(IEnumerable<AdjustmentDocument> items);
+
+    public partial AdjustmentDocumentBodyDto MapToDto(AdjustmentDocument item);
+}

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/AddAdjustmentDocumentLineCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/AddAdjustmentDocumentLineCommand.cs
@@ -1,0 +1,16 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Common.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+
+[PublicAPI]
+public sealed record AddAdjustmentDocumentLineCommand(
+    Guid DocumentId,
+    Guid ItemId,
+    Guid LocationId,
+    QuantityDeltaDto Delta,
+    string? Notes,
+    long DocumentVersion
+) : IRequest<Guid>, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/CreateAdjustmentDocumentCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/CreateAdjustmentDocumentCommand.cs
@@ -1,0 +1,14 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+
+namespace Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+
+[PublicAPI]
+public sealed record CreateAdjustmentDocumentCommand(
+    Guid WarehouseId,
+    string Code,
+    string Title,
+    string ReasonCode,
+    string? ReasonText
+) : IRequest<Guid>, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/DeleteAdjustmentDocumentCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/DeleteAdjustmentDocumentCommand.cs
@@ -1,0 +1,8 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+
+namespace Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+
+[PublicAPI]
+public record DeleteAdjustmentDocumentCommand(Guid Id, long Version) : IRequest, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/DeleteAdjustmentDocumentLineCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/DeleteAdjustmentDocumentLineCommand.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+
+namespace Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+
+[PublicAPI]
+public sealed record DeleteAdjustmentDocumentLineCommand(
+    Guid DocumentId,
+    Guid Id,
+    long DocumentVersion
+) : IRequest, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/PatchAdjustmentDocumentCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/PatchAdjustmentDocumentCommand.cs
@@ -1,0 +1,15 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+
+namespace Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+
+[PublicAPI]
+public sealed record PatchAdjustmentDocumentCommand(
+    Guid Id,
+    string? Code,
+    string? Title,
+    string? ReasonCode,
+    string? ReasonText,
+    long Version
+) : IRequest, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/PatchAdjustmentDocumentLineCommand.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Commands/PatchAdjustmentDocumentLineCommand.cs
@@ -1,0 +1,16 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Common.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+
+[PublicAPI]
+public sealed record PatchAdjustmentDocumentLineCommand(
+    Guid DocumentId,
+    Guid Id,
+    Guid? LocationId,
+    QuantityDeltaDto? Delta,
+    string? Notes,
+    long DocumentVersion
+) : IRequest, ITxRequest;

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Dtos/AdjustmentDocumentDto.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Dtos/AdjustmentDocumentDto.cs
@@ -12,6 +12,7 @@ public sealed record AdjustmentDocumentBodyDto(
     string ReasonCode,
     string? ReasonText,
     string Status,
+    string? Notes,
     DateTime CreatedAt,
     DateTime UpdatedAt,
     DateTime? PostedAt,

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Dtos/AdjustmentDocumentDto.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Dtos/AdjustmentDocumentDto.cs
@@ -1,0 +1,25 @@
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Common.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+
+[PublicAPI]
+public sealed record AdjustmentDocumentBodyDto(
+    Guid Id,
+    Guid WarehouseId,
+    string Code,
+    string Title,
+    string ReasonCode,
+    string? ReasonText,
+    string Status,
+    DateTime CreatedAt,
+    DateTime UpdatedAt,
+    DateTime? PostedAt,
+    long Version
+);
+
+[PublicAPI]
+public sealed record AdjustmentDocumentDto(
+    AdjustmentDocumentBodyDto Body,
+    List<AdjustmentDocumentLineDto> Lines
+);

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Dtos/AdjustmentDocumentLineDto.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Dtos/AdjustmentDocumentLineDto.cs
@@ -1,0 +1,14 @@
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Common.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+
+[PublicAPI]
+public sealed record AdjustmentDocumentLineDto(
+    Guid Id,
+    Guid DocumentId,
+    Guid LocationId,
+    Guid ItemId,
+    QuantityDeltaDto Delta,
+    string? Notes
+);

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Queries/GetAdjustmentDocumentLinesQuery.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Queries/GetAdjustmentDocumentLinesQuery.cs
@@ -1,0 +1,8 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Adjustment.Queries;
+
+[PublicAPI]
+public sealed record GetAdjustmentDocumentLinesQuery(Guid Id) : IRequest<List<AdjustmentDocumentLineDto>>;

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Queries/GetAdjustmentDocumentQuery.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Queries/GetAdjustmentDocumentQuery.cs
@@ -1,0 +1,8 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Adjustment.Queries;
+
+[PublicAPI]
+public sealed record GetAdjustmentDocumentQuery(Guid Id) : IRequest<AdjustmentDocumentDto>;

--- a/Nimbo.Wms.Contracts/Documents/Adjustment/Queries/GetAdjustmentDocumentsQuery.cs
+++ b/Nimbo.Wms.Contracts/Documents/Adjustment/Queries/GetAdjustmentDocumentsQuery.cs
@@ -1,0 +1,8 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+
+namespace Nimbo.Wms.Contracts.Documents.Adjustment.Queries;
+
+[PublicAPI]
+public record GetAdjustmentDocumentsQuery : IRequest<List<AdjustmentDocumentBodyDto>>;

--- a/Nimbo.Wms.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Nimbo.Wms.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.MasterData;
 using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Stock;
 using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Topology;
 using Nimbo.Wms.Application.Common.Behaviors;
+using Nimbo.Wms.Application.Mappings.Documents.Adjustment;
 using Nimbo.Wms.Application.Mappings.Documents.CycleCount;
 using Nimbo.Wms.Application.Mappings.MasterData;
 using Nimbo.Wms.Application.Mappings.Stock;
@@ -19,6 +20,7 @@ using Nimbo.Wms.Application.Mappings.Documents.Relocation;
 using Nimbo.Wms.Application.Mappings.Documents.Shipment;
 using Nimbo.Wms.Application.Services.Documents;
 using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
 using Nimbo.Wms.Contracts.Documents.CycleCount.Dtos;
 using Nimbo.Wms.Contracts.MasterData.Dtos;
 using Nimbo.Wms.Contracts.Stock.Dtos;
@@ -131,6 +133,9 @@ public static class ServiceCollectionExtensions
             services.AddScoped<IMapper<ShipmentDocument, ShipmentDocumentBodyDto>, ShipmentDocumentBodyMapper>();
             services.AddScoped<IMapper<ShipmentDocumentLine, ShipmentDocumentLineDto>, ShipmentDocumentLineMapper>();
             services.AddScoped<IMapper<ShipmentPickLine, ShipmentPickLineDto>, ShipmentPickLineMapper>();
+
+            services.AddScoped<IMapper<AdjustmentDocument, AdjustmentDocumentBodyDto>, AdjustmentDocumentBodyMapper>();
+            services.AddScoped<IMapper<AdjustmentDocumentLine, AdjustmentDocumentLineDto>, AdjustmentDocumentLineMapper>();
 
             services.AddScoped<IMapper<CycleCountDocument, CycleCountDocumentBodyDto>, CycleCountDocumentBodyMapper>();
             services.AddScoped<IMapper<CycleCountDocumentLine, CycleCountDocumentLineDto>, CycleCountDocumentLineMapper>();

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/AddAdjustmentDocumentLineCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/AddAdjustmentDocumentLineCommandHandler.cs
@@ -1,0 +1,46 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.MasterData;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+using Nimbo.Wms.Domain.Identification;
+using Nimbo.Wms.Domain.References;
+using Nimbo.Wms.Domain.ValueObject;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Adjustment;
+
+[PublicAPI]
+public class AddAdjustmentDocumentLineCommandHandler : IRequestHandler<AddAdjustmentDocumentLineCommand, Guid>
+{
+    private readonly IAdjustmentDocumentRepository _repository;
+    private readonly IItemRepository _itemRepository;
+
+    public AddAdjustmentDocumentLineCommandHandler(IAdjustmentDocumentRepository repository, IItemRepository itemRepository)
+    {
+        _repository = repository;
+        _itemRepository = itemRepository;
+    }
+
+    public async Task<Guid> Handle(AddAdjustmentDocumentLineCommand request, CancellationToken ct)
+    {
+        var documentId = AdjustmentDocumentId.From(request.DocumentId);
+        var document = await _repository.GetByIdWithLinesAsync(documentId, ct);
+        if (document is null)
+            throw new NotFoundException($"Adjustment document with ID '{documentId}' not found");
+
+        if (document.Version > request.DocumentVersion)
+            throw new ConcurrencyException($"Document version mismatch. Expected: {document.Version}, Actual: {request.DocumentVersion}");
+
+        var itemId = ItemId.From(request.ItemId);
+        var item = await _itemRepository.GetByIdAsync(itemId, ct);
+        if (item is null)
+            throw new InvalidOperationException($"Item with ID '{itemId}' not found");
+
+        var locationId = LocationId.From(request.LocationId);
+        var uom = Enum.Parse<UnitOfMeasure>(request.Delta.Uom);
+        var delta = new QuantityDelta(request.Delta.Value, uom);
+
+        return document.AddLine(itemId, locationId, delta, request.Notes);
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/CreateAdjustmentDocumentCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/CreateAdjustmentDocumentCommandHandler.cs
@@ -1,0 +1,32 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+using Nimbo.Wms.Domain.Entities.Documents.Adjustment;
+using Nimbo.Wms.Domain.Identification;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Adjustment;
+
+[PublicAPI]
+public class CreateAdjustmentDocumentCommandHandler : IRequestHandler<CreateAdjustmentDocumentCommand, Guid>
+{
+    private readonly IAdjustmentDocumentRepository _repository;
+
+    public CreateAdjustmentDocumentCommandHandler(IAdjustmentDocumentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Guid> Handle(CreateAdjustmentDocumentCommand request, CancellationToken ct)
+    {
+        var warehouseId = WarehouseId.From(request.WarehouseId);
+        var documentId = AdjustmentDocumentId.New();
+
+        var document = new AdjustmentDocument(documentId, warehouseId, request.Code, request.Title, DateTime.UtcNow);
+        document.ChangeReason(request.ReasonCode, request.ReasonText);
+
+        await _repository.AddAsync(document, ct);
+
+        return documentId.Value;
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/DeleteAdjustmentDocumentCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/DeleteAdjustmentDocumentCommandHandler.cs
@@ -1,0 +1,33 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+using Nimbo.Wms.Domain.Identification;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Adjustment;
+
+[PublicAPI]
+public class DeleteAdjustmentDocumentCommandHandler : IRequestHandler<DeleteAdjustmentDocumentCommand>
+{
+    private readonly IAdjustmentDocumentRepository _repository;
+
+    public DeleteAdjustmentDocumentCommandHandler(IAdjustmentDocumentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(DeleteAdjustmentDocumentCommand request, CancellationToken ct)
+    {
+        var documentId = AdjustmentDocumentId.From(request.Id);
+        var document = await _repository.GetByIdWithLinesAsync(documentId, ct);
+        if (document is null)
+            throw new NotFoundException($"Adjustment document with ID '{documentId}' not found");
+
+        if (document.Version > request.Version)
+            throw new ConcurrencyException($"Document version mismatch. Expected: {document.Version}, Actual: {request.Version}");
+
+        document.EnsureCanBeEdited();
+        await _repository.DeleteAsync(document, ct);
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/DeleteAdjustmentDocumentLineCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/DeleteAdjustmentDocumentLineCommandHandler.cs
@@ -1,0 +1,32 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+using Nimbo.Wms.Domain.Identification;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Adjustment;
+
+[PublicAPI]
+public class DeleteAdjustmentDocumentLineCommandHandler : IRequestHandler<DeleteAdjustmentDocumentLineCommand>
+{
+    private readonly IAdjustmentDocumentRepository _repository;
+
+    public DeleteAdjustmentDocumentLineCommandHandler(IAdjustmentDocumentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(DeleteAdjustmentDocumentLineCommand request, CancellationToken ct)
+    {
+        var documentId = AdjustmentDocumentId.From(request.DocumentId);
+        var document = await _repository.GetByIdWithLinesAsync(documentId, ct);
+        if (document is null)
+            throw new NotFoundException($"Adjustment document with ID '{documentId}' not found");
+
+        if (document.Version > request.DocumentVersion)
+            throw new ConcurrencyException($"Document version mismatch. Expected: {document.Version}, Actual: {request.DocumentVersion}");
+
+        document.RemoveLine(request.Id);
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/GetAdjustmentDocumentLinesQueryHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/GetAdjustmentDocumentLinesQueryHandler.cs
@@ -1,0 +1,35 @@
+using JetBrains.Annotations;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Queries;
+using Nimbo.Wms.Domain.Entities.Documents.Adjustment;
+using Nimbo.Wms.Domain.Identification;
+using Nimbo.Wms.Infrastructure.Persistence;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Adjustment;
+
+[PublicAPI]
+public class GetAdjustmentDocumentLinesQueryHandler : IRequestHandler<GetAdjustmentDocumentLinesQuery, List<AdjustmentDocumentLineDto>>
+{
+    private readonly NimboWmsDbContext _dbContext;
+    private readonly IMapper<AdjustmentDocumentLine, AdjustmentDocumentLineDto> _mapper;
+
+    public GetAdjustmentDocumentLinesQueryHandler(NimboWmsDbContext dbContext, IMapper<AdjustmentDocumentLine, AdjustmentDocumentLineDto> mapper)
+    {
+        _dbContext = dbContext;
+        _mapper = mapper;
+    }
+
+    public async Task<List<AdjustmentDocumentLineDto>> Handle(GetAdjustmentDocumentLinesQuery request, CancellationToken cancellationToken)
+    {
+        var documentId = AdjustmentDocumentId.From(request.Id);
+        var dbQuery = _dbContext.Set<AdjustmentDocumentLine>()
+            .AsNoTracking()
+            .Where(l => l.DocumentId == documentId);
+
+        var lines = await _mapper.ProjectToDto(dbQuery).ToListAsync(cancellationToken);
+        return lines;
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/GetAdjustmentDocumentQueryHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/GetAdjustmentDocumentQueryHandler.cs
@@ -1,0 +1,46 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Queries;
+using Nimbo.Wms.Domain.Entities.Documents.Adjustment;
+using Nimbo.Wms.Infrastructure.Persistence;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Adjustment;
+
+public class GetAdjustmentDocumentQueryHandler : IRequestHandler<GetAdjustmentDocumentQuery, AdjustmentDocumentDto>
+{
+    private readonly NimboWmsDbContext _dbContext;
+    private readonly IMapper<AdjustmentDocument, AdjustmentDocumentBodyDto> _bodyMapper;
+    private readonly IMapper<AdjustmentDocumentLine, AdjustmentDocumentLineDto> _lineMapper;
+
+    public GetAdjustmentDocumentQueryHandler(
+        NimboWmsDbContext dbContext,
+        IMapper<AdjustmentDocument, AdjustmentDocumentBodyDto> bodyMapper,
+        IMapper<AdjustmentDocumentLine, AdjustmentDocumentLineDto> lineMapper)
+    {
+        _dbContext = dbContext;
+        _bodyMapper = bodyMapper;
+        _lineMapper = lineMapper;
+    }
+
+    public async Task<AdjustmentDocumentDto> Handle(GetAdjustmentDocumentQuery request, CancellationToken ct)
+    {
+        var dbQuery = _dbContext.Set<AdjustmentDocument>()
+            .AsNoTracking()
+            .Where(d => d.Id == request.Id)
+            .Include(d => d.Lines);
+
+        var document = await dbQuery.Select(d =>
+                new AdjustmentDocumentDto(
+                    _bodyMapper.MapToDto(d),
+                    _lineMapper.MapToDto(d.Lines).ToList()))
+            .SingleOrDefaultAsync(ct);
+            
+        if (document is null)
+            throw new NotFoundException($"Adjustment document with ID {request.Id} not found");
+
+        return document;
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/GetAdjustmentDocumentsQueryHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/GetAdjustmentDocumentsQueryHandler.cs
@@ -1,0 +1,30 @@
+using JetBrains.Annotations;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Nimbo.Wms.Contracts.Common;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Queries;
+using Nimbo.Wms.Domain.Entities.Documents.Adjustment;
+using Nimbo.Wms.Infrastructure.Persistence;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Adjustment;
+
+[PublicAPI]
+public class GetAdjustmentDocumentsQueryHandler : IRequestHandler<GetAdjustmentDocumentsQuery, List<AdjustmentDocumentBodyDto>>
+{
+    private readonly NimboWmsDbContext _dbContext;
+    private readonly IMapper<AdjustmentDocument, AdjustmentDocumentBodyDto> _mapper;
+
+    public GetAdjustmentDocumentsQueryHandler(NimboWmsDbContext dbContext, IMapper<AdjustmentDocument, AdjustmentDocumentBodyDto> mapper)
+    {
+        _dbContext = dbContext;
+        _mapper = mapper;
+    }
+
+    public async Task<List<AdjustmentDocumentBodyDto>> Handle(GetAdjustmentDocumentsQuery request, CancellationToken ct)
+    {
+        var dbQuery = _dbContext.Set<AdjustmentDocument>().AsNoTracking();
+        var documents = await _mapper.ProjectToDto(dbQuery).ToListAsync(ct);
+        return documents;
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/PatchAdjustmentDocumentCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/PatchAdjustmentDocumentCommandHandler.cs
@@ -1,0 +1,39 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+using Nimbo.Wms.Domain.Identification;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Adjustment;
+
+[PublicAPI]
+public class PatchAdjustmentDocumentCommandHandler : IRequestHandler<PatchAdjustmentDocumentCommand>
+{
+    private readonly IAdjustmentDocumentRepository _repository;
+
+    public PatchAdjustmentDocumentCommandHandler(IAdjustmentDocumentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(PatchAdjustmentDocumentCommand request, CancellationToken ct)
+    {
+        var documentId = AdjustmentDocumentId.From(request.Id);
+        var document = await _repository.GetByIdAsync(documentId, ct);
+        if (document is null)
+            throw new NotFoundException($"Adjustment document with ID '{documentId}' not found.");
+
+        if (document.Version > request.Version)
+            throw new ConcurrencyException($"Document version mismatch. Expected: {document.Version}, Actual: {request.Version}");
+
+        if (!string.IsNullOrWhiteSpace(request.Code))
+            document.ChangeCode(request.Code);
+
+        if (!string.IsNullOrWhiteSpace(request.Title))
+            document.ChangeTitle(request.Title);
+
+        if (!string.IsNullOrWhiteSpace(request.ReasonCode))
+            document.ChangeReason(request.ReasonCode, request.ReasonText ?? document.ReasonText);
+    }
+}

--- a/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/PatchAdjustmentDocumentLineCommandHandler.cs
+++ b/Nimbo.Wms.Infrastructure/UseCases/Documents/Adjustment/PatchAdjustmentDocumentLineCommandHandler.cs
@@ -1,0 +1,49 @@
+using JetBrains.Annotations;
+using MediatR;
+using Nimbo.Wms.Application.Abstractions.Persistence.Repositories.Documents;
+using Nimbo.Wms.Application.Common;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+using Nimbo.Wms.Domain.Identification;
+using Nimbo.Wms.Domain.References;
+using Nimbo.Wms.Domain.ValueObject;
+
+namespace Nimbo.Wms.Infrastructure.UseCases.Documents.Adjustment;
+
+[PublicAPI]
+public class PatchAdjustmentDocumentLineCommandHandler : IRequestHandler<PatchAdjustmentDocumentLineCommand>
+{
+    private readonly IAdjustmentDocumentRepository _repository;
+
+    public PatchAdjustmentDocumentLineCommandHandler(IAdjustmentDocumentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(PatchAdjustmentDocumentLineCommand request, CancellationToken ct)
+    {
+        var documentId = AdjustmentDocumentId.From(request.DocumentId);
+        var document = await _repository.GetByIdWithLinesAsync(documentId, ct);
+        if (document is null)
+            throw new NotFoundException($"Adjustment document with ID '{documentId}' not found");
+
+        if (document.Version > request.DocumentVersion)
+            throw new ConcurrencyException($"Document version mismatch. Expected: {document.Version}, Actual: {request.DocumentVersion}");
+
+        if (request.Delta is not null)
+        {
+            var uom = Enum.Parse<UnitOfMeasure>(request.Delta.Uom);
+            var delta = new QuantityDelta(request.Delta.Value, uom);
+            document.ChangeLineDelta(request.Id, delta);
+        }
+
+        if (request.LocationId.HasValue)
+        {
+            document.ChangeLineLocation(request.Id, LocationId.From(request.LocationId.Value));
+        }
+
+        if (request.Notes is not null)
+        {
+            document.ChangeLineNotes(request.Id, request.Notes);
+        }
+    }
+}

--- a/Nimbo.Wms/Controllers/Documents/AdjustmentDocumentLinesController.cs
+++ b/Nimbo.Wms/Controllers/Documents/AdjustmentDocumentLinesController.cs
@@ -1,0 +1,106 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Queries;
+using Nimbo.Wms.Models.Documents.Adjustment;
+
+namespace Nimbo.Wms.Controllers.Documents;
+
+[ApiController]
+[Route("api/documents/adjustment/{documentGuid:guid}/lines")]
+public class AdjustmentDocumentLinesController(ISender sender) : ControllerBase
+{
+    /// <summary>
+    /// Adds a line to an adjustment document with the specified details.
+    /// </summary>
+    /// <param name="documentGuid">The unique identifier of the adjustment document to which the line will be added.</param>
+    /// <param name="request">The request containing the details of the line to be added, including item, location, delta, notes, and document version.</param>
+    /// <param name="ct">The cancellation token used to cancel the asynchronous operation.</param>
+    /// <returns>Returns an <see cref="IActionResult"/> indicating the result of the operation, with a created status and response containing the ID of the newly added line.</returns>
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [Produces("application/json")]
+    public async Task<IActionResult> AddLine(
+        Guid documentGuid,
+        [FromBody] AddAdjustmentDocumentLineRequest request,
+        CancellationToken ct)
+    {
+        var command = new AddAdjustmentDocumentLineCommand(
+            documentGuid,
+            request.ItemId,
+            request.LocationId,
+            request.Delta,
+            request.Notes,
+            request.DocumentVersion);
+        var lineId = await sender.Send(command, ct);
+
+        return Created(string.Empty, new AddAdjustmentDocumentLineResponse(lineId));
+    }
+
+    /// <summary>
+    /// Retrieves the list of adjustment document lines associated with the specified document.
+    /// </summary>
+    /// <param name="documentGuid">The unique identifier of the adjustment document whose lines are being retrieved.</param>
+    /// <param name="ct">The cancellation token used to cancel the asynchronous operation.</param>
+    /// <returns>Returns a read-only list of <see cref="AdjustmentDocumentLineDto"/> objects representing the lines of the adjustment document.</returns>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [Produces("application/json")]
+    public async Task<IReadOnlyList<AdjustmentDocumentLineDto>> GetLines(Guid documentGuid, CancellationToken ct)
+    {
+        var query = new GetAdjustmentDocumentLinesQuery(documentGuid);
+        return await sender.Send(query, ct);
+    }
+
+    /// <summary>
+    /// Updates an existing line in an adjustment document with the provided details.
+    /// </summary>
+    /// <param name="documentGuid">The unique identifier of the adjustment document containing the line to be updated.</param>
+    /// <param name="lineGuid">The unique identifier of the line to be updated.</param>
+    /// <param name="request">The request object containing the updated details for the line, including the location, delta, notes, and document version.</param>
+    /// <param name="ct">The cancellation token used to cancel the asynchronous operation.</param>
+    /// <returns>Returns an <see cref="IActionResult"/> indicating the result of the operation, with no content if successful or a not found status if the line does not exist.</returns>
+    [HttpPatch("{lineGuid:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> PatchLine(
+        Guid documentGuid,
+        Guid lineGuid,
+        [FromBody] PatchAdjustmentDocumentLineRequest request,
+        CancellationToken ct)
+    {
+        var command = new PatchAdjustmentDocumentLineCommand(
+            documentGuid,
+            lineGuid,
+            request.LocationId,
+            request.Delta,
+            request.Notes,
+            request.DocumentVersion);
+        await sender.Send(command, ct);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Deletes a specific line from an adjustment document based on the provided document and line identifiers.
+    /// </summary>
+    /// <param name="documentGuid">The unique identifier of the adjustment document from which the line will be deleted.</param>
+    /// <param name="lineGuid">The unique identifier of the line to be deleted.</param>
+    /// <param name="documentVersion">The version of the adjustment document to ensure consistency during deletion.</param>
+    /// <param name="ct">The cancellation token used to cancel the asynchronous operation.</param>
+    /// <returns>Returns an <see cref="IActionResult"/> indicating the result of the operation, with a no-content status if successful or not found if the line does not exist.</returns>
+    [HttpDelete("{lineGuid:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteLine(
+        Guid documentGuid,
+        Guid lineGuid,
+        [FromQuery] long documentVersion,
+        CancellationToken ct)
+    {
+        var command = new DeleteAdjustmentDocumentLineCommand(documentGuid, lineGuid, documentVersion);
+        await sender.Send(command, ct);
+        return NoContent();
+    }
+}

--- a/Nimbo.Wms/Controllers/Documents/AdjustmentDocumentsController.cs
+++ b/Nimbo.Wms/Controllers/Documents/AdjustmentDocumentsController.cs
@@ -1,0 +1,141 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Commands;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Dtos;
+using Nimbo.Wms.Contracts.Documents.Adjustment.Queries;
+using Nimbo.Wms.Models.Documents.Adjustment;
+
+namespace Nimbo.Wms.Controllers.Documents;
+
+[ApiController]
+[Route("api/documents/adjustment")]
+public class AdjustmentDocumentsController(ISender sender) : ControllerBase
+{
+    /// Creates a new adjustment document and returns its identifier.
+    /// <param name="request">
+    /// The request object containing details necessary to create an adjustment document.
+    /// Includes properties such as WarehouseId, Code, Title, ReasonCode, and optional ReasonText.
+    /// </param>
+    /// <param name="ct">
+    /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+    /// </param>
+    /// <returns>
+    /// An IActionResult containing the status of the operation. If successful, returns a 201 Created response
+    /// with a CreateAdjustmentDocumentResponse containing the identifier of the newly created document.
+    /// </returns>
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [Produces("application/json")]
+    public async Task<IActionResult> CreateDocument(
+        [FromBody] CreateAdjustmentDocumentRequest request,
+        CancellationToken ct)
+    {
+        var command = new CreateAdjustmentDocumentCommand(
+            request.WarehouseId,
+            request.Code,
+            request.Title,
+            request.ReasonCode,
+            request.ReasonText);
+        var documentGuid = await sender.Send(command, ct);
+
+        return CreatedAtAction(
+            actionName: nameof(GetDocument),
+            new { documentGuid = documentGuid },
+            new CreateAdjustmentDocumentResponse(documentGuid));
+    }
+
+    /// Retrieves a list of all adjustment documents in the system.
+    /// <param name="ct">
+    /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+    /// </param>
+    /// <returns>
+    /// A read-only list of AdjustmentDocumentBodyDto objects representing the adjustment documents.
+    /// </returns>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [Produces("application/json")]
+    public async Task<IReadOnlyList<AdjustmentDocumentBodyDto>> GetDocuments(CancellationToken ct)
+    {
+        var query = new GetAdjustmentDocumentsQuery();
+        return await sender.Send(query, ct);
+    }
+
+    /// Retrieves an existing adjustment document based on its unique identifier.
+    /// <param name="documentGuid">
+    /// The unique identifier of the adjustment document to be retrieved.
+    /// </param>
+    /// <param name="ct">
+    /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+    /// </param>
+    /// <returns>
+    /// An AdjustmentDocumentDto containing the details of the requested adjustment document if found.
+    /// If the document is not found, returns a 404 Not Found response.
+    /// </returns>
+    [HttpGet("{documentGuid:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [Produces("application/json")]
+    public async Task<AdjustmentDocumentDto> GetDocument(Guid documentGuid, CancellationToken ct)
+    {
+        var query = new GetAdjustmentDocumentQuery(documentGuid);
+        return await sender.Send(query, ct);
+    }
+
+    /// Updates an existing adjustment document with new details.
+    /// <param name="documentGuid">
+    /// The unique identifier of the adjustment document to be updated.
+    /// </param>
+    /// <param name="request">
+    /// The request object containing the new details for the adjustment document.
+    /// Includes properties such as Code, Title, ReasonCode, ReasonText, and the Version of the document to prevent concurrency issues.
+    /// </param>
+    /// <param name="ct">
+    /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+    /// </param>
+    /// <returns>
+    /// An IActionResult indicating the result of the update operation. If the update is successful, a 204 No Content response is returned.
+    /// If the document is not found, a 404 Not Found response is returned.
+    /// </returns>
+    [HttpPatch("{documentGuid:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> PatchDocument(
+        Guid documentGuid,
+        [FromBody] PatchAdjustmentDocumentRequest request,
+        CancellationToken ct)
+    {
+        var command = new PatchAdjustmentDocumentCommand(
+            documentGuid,
+            request.Code,
+            request.Title,
+            request.ReasonCode,
+            request.ReasonText,
+            request.Version);
+        await sender.Send(command, ct);
+        return NoContent();
+    }
+
+    /// Deletes an existing adjustment document based on the provided identifier and version.
+    /// <param name="documentGuid">
+    /// The unique identifier of the adjustment document to be deleted.
+    /// </param>
+    /// <param name="version">
+    /// The specific version of the adjustment document to ensure concurrency handling during deletion.
+    /// </param>
+    /// <param name="ct">
+    /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+    /// </param>
+    /// <returns>
+    /// An IActionResult indicating the result of the operation. Returns a 204 No Content response if the deletion is successful,
+    /// or a 404 Not Found response if the document does not exist.
+    /// </returns>
+    [HttpDelete("{documentGuid:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteDocument(Guid documentGuid, [FromQuery] long version, CancellationToken ct)
+    {
+        var command = new DeleteAdjustmentDocumentCommand(documentGuid, version);
+        await sender.Send(command, ct);
+        return NoContent();
+    }
+}

--- a/Nimbo.Wms/Models/Documents/Adjustment/AddAdjustmentDocumentLineRequest.cs
+++ b/Nimbo.Wms/Models/Documents/Adjustment/AddAdjustmentDocumentLineRequest.cs
@@ -1,0 +1,16 @@
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Common.Dtos;
+
+namespace Nimbo.Wms.Models.Documents.Adjustment;
+
+[PublicAPI]
+public sealed record AddAdjustmentDocumentLineRequest(
+    Guid ItemId,
+    Guid LocationId,
+    QuantityDeltaDto Delta,
+    string? Notes,
+    long DocumentVersion
+);
+
+[PublicAPI]
+public sealed record AddAdjustmentDocumentLineResponse(Guid Id);

--- a/Nimbo.Wms/Models/Documents/Adjustment/CreateAdjustmentDocumentRequest.cs
+++ b/Nimbo.Wms/Models/Documents/Adjustment/CreateAdjustmentDocumentRequest.cs
@@ -1,0 +1,15 @@
+using JetBrains.Annotations;
+
+namespace Nimbo.Wms.Models.Documents.Adjustment;
+
+[PublicAPI]
+public sealed record CreateAdjustmentDocumentRequest(
+    Guid WarehouseId,
+    string Code,
+    string Title,
+    string ReasonCode,
+    string? ReasonText
+);
+
+[PublicAPI]
+public sealed record CreateAdjustmentDocumentResponse(Guid Id);

--- a/Nimbo.Wms/Models/Documents/Adjustment/PatchAdjustmentDocumentLineRequest.cs
+++ b/Nimbo.Wms/Models/Documents/Adjustment/PatchAdjustmentDocumentLineRequest.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+using Nimbo.Wms.Contracts.Common.Dtos;
+
+namespace Nimbo.Wms.Models.Documents.Adjustment;
+
+[PublicAPI]
+public sealed record PatchAdjustmentDocumentLineRequest(
+    Guid? LocationId,
+    QuantityDeltaDto? Delta,
+    string? Notes,
+    long DocumentVersion
+);

--- a/Nimbo.Wms/Models/Documents/Adjustment/PatchAdjustmentDocumentRequest.cs
+++ b/Nimbo.Wms/Models/Documents/Adjustment/PatchAdjustmentDocumentRequest.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+
+namespace Nimbo.Wms.Models.Documents.Adjustment;
+
+[PublicAPI]
+public sealed record PatchAdjustmentDocumentRequest(
+    string? Code,
+    string? Title,
+    string? ReasonCode,
+    string? ReasonText,
+    long Version
+);


### PR DESCRIPTION
This PR implements the adjustment document feature. It includes the following:

- CRUD endpoints for adjustment documents and their lines.
- Handlers to manage business logic for adjustment document-related operations.
- Validators and mappers to ensure data consistency and domain transformations.
- Updates to DTOs, introducing a `Notes` field to handle additional comments.